### PR TITLE
Make Crucible settings application wide

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -33,10 +33,12 @@
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">
-    <projectConfigurable instance="com.jetbrains.crucible.configuration.CrucibleConfigurable"
-                           id="com.jetbrains.crucible.configuration.CrucibleConfigurable" displayName="Crucible Connector"/>
-    <projectService serviceInterface="com.jetbrains.crucible.configuration.CrucibleSettings"
-                    serviceImplementation="com.jetbrains.crucible.configuration.CrucibleSettings"/>
+    <applicationConfigurable instance="com.jetbrains.crucible.configuration.CrucibleConfigurable"
+                             id="com.jetbrains.crucible.configuration.CrucibleConfigurable" displayName="Crucible Connector"/>
+    <applicationService serviceInterface="com.jetbrains.crucible.configuration.CrucibleSettings"
+                        serviceImplementation="com.jetbrains.crucible.configuration.CrucibleSettings"/>
+    <projectService serviceInterface="com.jetbrains.crucible.connection.CrucibleManager"
+                    serviceImplementation="com.jetbrains.crucible.connection.CrucibleManager" />
 
     <toolWindow id="Crucible connector" anchor="bottom" canCloseContents="true" factoryClass="com.jetbrains.crucible.ui.toolWindow.CrucibleToolWindowFactory"/>
   </extensions>

--- a/src/com/jetbrains/crucible/configuration/CrucibleConfigurable.java
+++ b/src/com/jetbrains/crucible/configuration/CrucibleConfigurable.java
@@ -4,7 +4,7 @@ import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
-import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.text.StringUtil;
 import com.jetbrains.crucible.connection.CrucibleTestConnectionTask;
 import org.jetbrains.annotations.Nls;
@@ -21,7 +21,6 @@ import java.awt.event.ActionListener;
  * User: ktisha
  */
 public class CrucibleConfigurable implements SearchableConfigurable {
-  private final Project myProject;
   private JPanel myMainPanel;
   private JTextField myServerField;
   private JTextField myUsernameField;
@@ -31,15 +30,14 @@ public class CrucibleConfigurable implements SearchableConfigurable {
   private static final String DEFAULT_PASSWORD_TEXT = "************";
   private boolean myPasswordModified;
 
-  public CrucibleConfigurable(Project project) {
-    myProject = project;
-    myCrucibleSettings = CrucibleSettings.getInstance(myProject);
+  public CrucibleConfigurable() {
+    myCrucibleSettings = CrucibleSettings.getInstance();
 
     myTestButton.addActionListener(new ActionListener() {
       @Override
       public void actionPerformed(ActionEvent e) {
         saveSettings();
-        final Task.Modal testConnectionTask = new CrucibleTestConnectionTask(myProject, true);
+        final Task.Modal testConnectionTask = new CrucibleTestConnectionTask(ProjectManager.getInstance().getDefaultProject(), true);
         ProgressManager.getInstance().run(testConnectionTask);
       }
     }

--- a/src/com/jetbrains/crucible/configuration/CrucibleSettings.java
+++ b/src/com/jetbrains/crucible/configuration/CrucibleSettings.java
@@ -4,7 +4,6 @@ import com.intellij.ide.passwordSafe.PasswordSafe;
 import com.intellij.ide.passwordSafe.PasswordSafeException;
 import com.intellij.openapi.components.*;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,8 +12,7 @@ import org.jetbrains.annotations.Nullable;
  */
 @State(name = "CrucibleSettings",
        storages = {
-         @Storage(file = StoragePathMacros.PROJECT_FILE),
-         @Storage(file = StoragePathMacros.PROJECT_CONFIG_DIR + "/crucibleConnector.xml", scheme = StorageScheme.DIRECTORY_BASED)
+         @Storage(file = StoragePathMacros.APP_CONFIG + "/crucibleConnector.xml")
        }
 )
 public class CrucibleSettings implements PersistentStateComponent<CrucibleSettings> {
@@ -31,8 +29,8 @@ public class CrucibleSettings implements PersistentStateComponent<CrucibleSettin
     XmlSerializerUtil.copyBean(state, this);
   }
 
-  public static CrucibleSettings getInstance(Project project) {
-    return ServiceManager.getService(project, CrucibleSettings.class);
+  public static CrucibleSettings getInstance() {
+    return ServiceManager.getService(CrucibleSettings.class);
   }
 
   public static final String CRUCIBLE_SETTINGS_PASSWORD_KEY = "CRUCIBLE_SETTINGS_PASSWORD_KEY";

--- a/src/com/jetbrains/crucible/connection/CrucibleManager.java
+++ b/src/com/jetbrains/crucible/connection/CrucibleManager.java
@@ -1,5 +1,6 @@
 package com.jetbrains.crucible.connection;
 
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.jetbrains.crucible.configuration.CrucibleSettings;
@@ -21,20 +22,18 @@ import java.util.Map;
  */
 public class CrucibleManager {
   private final Project myProject;
-  private static CrucibleManager ourInstance;
   private final Map<String, CrucibleSession> mySessions = new HashMap<String, CrucibleSession>();
 
   private static final Logger LOG = Logger.getInstance(CrucibleManager.class.getName());
 
+  // implicitly constructed by pico container
+  @SuppressWarnings("UnusedDeclaration")
   private CrucibleManager(@NotNull final Project project) {
     myProject = project;
   }
 
   public static CrucibleManager getInstance(@NotNull final Project project) {
-    if (ourInstance == null) {
-      ourInstance = new CrucibleManager(project);
-    }
-    return ourInstance;
+    return ServiceManager.getService(project, CrucibleManager.class);
   }
 
   @Nullable
@@ -62,7 +61,7 @@ public class CrucibleManager {
   }
 
   public CrucibleSession getSession() throws CrucibleApiException {
-    final CrucibleSettings crucibleSettings = CrucibleSettings.getInstance(myProject);
+    final CrucibleSettings crucibleSettings = CrucibleSettings.getInstance();
     String key = crucibleSettings.SERVER_URL + crucibleSettings.USERNAME + crucibleSettings.getPassword();
     CrucibleSession session = mySessions.get(key);
     if (session == null) {

--- a/src/com/jetbrains/crucible/connection/CrucibleSessionImpl.java
+++ b/src/com/jetbrains/crucible/connection/CrucibleSessionImpl.java
@@ -39,14 +39,9 @@ public class CrucibleSessionImpl implements CrucibleSession {
   private final Project myProject;
   private String myAuthentification;
   private static final Logger LOG = Logger.getInstance(CrucibleSessionImpl.class.getName());
-  private final VirtualFile[] myRoots;
 
   CrucibleSessionImpl(Project project) {
     myProject = project;
-    final ProjectLevelVcsManager vcsManager = ProjectLevelVcsManager.getInstance(myProject);
-    final VirtualFile virtualFile = myProject.getBaseDir();
-    final AbstractVcs vcsFor = vcsManager.getVcsFor(virtualFile);
-    myRoots = vcsManager.getRootsUnderVcs(vcsFor);
   }
 
   @Override
@@ -148,15 +143,15 @@ public class CrucibleSessionImpl implements CrucibleSession {
   }
 
   private String getUsername() {
-    return CrucibleSettings.getInstance(myProject).USERNAME;
+    return CrucibleSettings.getInstance().USERNAME;
   }
 
   private String getPassword() {
-    return CrucibleSettings.getInstance(myProject).getPassword();
+    return CrucibleSettings.getInstance().getPassword();
   }
 
   private String getHostUrl() {
-    return UrlUtil.removeUrlTrailingSlashes(CrucibleSettings.getInstance(myProject).SERVER_URL);
+    return UrlUtil.removeUrlTrailingSlashes(CrucibleSettings.getInstance().SERVER_URL);
   }
 
   @Nullable
@@ -323,7 +318,7 @@ public class CrucibleSessionImpl implements CrucibleSession {
 
   @Nullable
   private VirtualFile findFileInRoots(String file) {
-    for (VirtualFile root : myRoots) {
+    for (VirtualFile root : getRoots()) {
       final VirtualFile virtualFile = root.findFileByRelativePath(file);
       if (virtualFile != null) {
         return virtualFile;
@@ -332,6 +327,13 @@ public class CrucibleSessionImpl implements CrucibleSession {
       }
     }
     return null;
+  }
+
+  private VirtualFile[] getRoots() {
+    final ProjectLevelVcsManager vcsManager = ProjectLevelVcsManager.getInstance(myProject);
+    final VirtualFile virtualFile = myProject.getBaseDir();
+    final AbstractVcs vcsFor = vcsManager.getVcsFor(virtualFile);
+    return vcsManager.getRootsUnderVcs(vcsFor);
   }
 
   private BasicReview parseBasicReview(Element element) throws CrucibleApiException {

--- a/src/com/jetbrains/crucible/ui/toolWindow/CrucibleToolWindowFactory.java
+++ b/src/com/jetbrains/crucible/ui/toolWindow/CrucibleToolWindowFactory.java
@@ -20,7 +20,7 @@ public class CrucibleToolWindowFactory implements ToolWindowFactory, DumbAware {
   public void createToolWindowContent(Project project, ToolWindow toolWindow) {
     DiffManager.getInstance().registerDiffTool(new CommentsDiffTool());
     final ContentManager contentManager = toolWindow.getContentManager();
-    if (StringUtil.isEmptyOrSpaces(CrucibleSettings.getInstance(project).SERVER_URL)) return;
+    if (StringUtil.isEmptyOrSpaces(CrucibleSettings.getInstance().SERVER_URL)) return;
     CruciblePanel cruciblePanel = new CruciblePanel(project);
     final Content content = ContentFactory.SERVICE.getInstance().createContent(cruciblePanel, "Crucible", false);
 


### PR DESCRIPTION
- Let CrucibleManager be a project service.
  It seems that it was intended to be a project singleton,
  but appeared to be an application singleton with myProject
  remembered forever.
- Make CrucibleConfigurable be an applicationConfigurable, and
  CrucibleSettings be an application service, and store it in the
  APP_CONFIG folder.
  Since the CrucibleTestConnectionTask requires a project, give it the
  default project. Actually, the project is needed only for the
  CrucibleSessionImpl, and not for the logic request,
  but it can be fixed later.
- CrucibleSessionImpl: don't calculate roots in the constructor,
  do it on demand (otherwise calculating roots for default project
  leads to an error, and it is not needed here anyway).
