### PR TITLE
#36 Fix adding and showing comments for the diff chain

### DIFF
--- a/src/com/jetbrains/crucible/ui/toolWindow/diff/CommentsDiffTool.java
+++ b/src/com/jetbrains/crucible/ui/toolWindow/diff/CommentsDiffTool.java
@@ -1,23 +1,28 @@
 package com.jetbrains.crucible.ui.toolWindow.diff;
 
 import com.intellij.ide.DataManager;
-import com.intellij.openapi.actionSystem.*;
-import com.intellij.openapi.diff.DiffContent;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.diff.DiffRequest;
 import com.intellij.openapi.diff.impl.DiffPanelImpl;
+import com.intellij.openapi.diff.impl.external.DiffManagerImpl;
 import com.intellij.openapi.diff.impl.external.FrameDiffTool;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.markup.HighlighterLayer;
 import com.intellij.openapi.editor.markup.MarkupModel;
 import com.intellij.openapi.editor.markup.RangeHighlighter;
-import com.intellij.openapi.keymap.KeymapManager;
-import com.intellij.openapi.ui.DialogBuilder;
 import com.intellij.openapi.util.AsyncResult;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vcs.FilePath;
+import com.intellij.openapi.vcs.FilePathImpl;
 import com.intellij.openapi.vcs.VcsDataKeys;
 import com.intellij.openapi.vcs.changes.Change;
+import com.intellij.openapi.vcs.changes.ChangeRequestChain;
 import com.intellij.openapi.vcs.changes.ContentRevision;
+import com.intellij.openapi.vcs.changes.actions.DiffRequestPresentable;
+import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.PopupHandler;
 import com.jetbrains.crucible.actions.AddCommentAction;
@@ -28,12 +33,17 @@ import com.jetbrains.crucible.utils.CrucibleDataKeys;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.awt.*;
 import java.util.List;
 
 /**
  * User: ktisha
  */
 public class CommentsDiffTool extends FrameDiffTool {
+
+  @Nullable private Review myReview;
+  @Nullable private Change[] myChanges;
+
   @Override
   public boolean canShow(DiffRequest request) {
     final boolean superCanShow = super.canShow(request);
@@ -44,46 +54,19 @@ public class CommentsDiffTool extends FrameDiffTool {
     return superCanShow && review != null;
   }
 
+  @Nullable
   @Override
-  public void show(DiffRequest request) {
-    final DiffContent[] contents = request.getContents();
-    if (contents.length != 2) return;
-
-    final DialogBuilder builder = new DialogBuilder(request.getProject());
-    final DiffPanelImpl diffPanel = (DiffPanelImpl)createComponent("", request, builder.getWindow(), builder);
-    if (diffPanel == null) {
-      Disposer.dispose(builder);
-      return;
-    }
-
+  protected DiffPanelImpl createDiffPanelImpl(@NotNull DiffRequest request, @Nullable Window window, @NotNull Disposable parentDisposable) {
     final AsyncResult<DataContext> dataContextFromFocus = DataManager.getInstance().getDataContextFromFocus();
     final DataContext context = dataContextFromFocus.getResult();
-    if (context == null) return;
-    final Review review = CrucibleDataKeys.REVIEW.getData(context);
-    final Change[] changes = VcsDataKeys.CHANGE_LEAD_SELECTION.getData(context);
-    final VirtualFile vFile = PlatformDataKeys.VIRTUAL_FILE.getData(context);
-    final Editor editor2 = diffPanel.getEditor2();
+    if (context == null) return null;
+    myReview = CrucibleDataKeys.REVIEW.getData(context);
+    myChanges = VcsDataKeys.SELECTED_CHANGES.getData(context);
 
-    addCommentAction(editor2, vFile, review);
-
-    builder.removeAllActions();
-    builder.setCenterPanel(diffPanel.getComponent());
-    builder.setPreferredFocusComponent(diffPanel.getPreferredFocusedComponent());
-    builder.setTitle(request.getWindowTitle());
-    builder.setDimensionServiceKey(request.getGroupKey());
-
-    new AnAction() {
-      public void actionPerformed(final AnActionEvent e) {
-        builder.getDialogWrapper().close(0);
-      }
-    }.registerCustomShortcutSet(new CustomShortcutSet(KeymapManager.getInstance().getActiveKeymap().getShortcuts("CloseContent")),
-                                diffPanel.getComponent());
-
-    if (changes != null && changes.length == 1 && review != null && vFile != null) {
-      final ContentRevision revision = changes[0].getAfterRevision();
-      addGutter(review, revision, vFile, editor2);
-    }
-    builder.showModal(true);
+    DiffPanelImpl diffPanel = new CommentableDiffPanel(window, request);
+    diffPanel.setDiffRequest(request);
+    Disposer.register(parentDisposable, diffPanel);
+    return diffPanel;
   }
 
   private static void addCommentAction(@Nullable final Editor editor2,
@@ -102,12 +85,12 @@ public class CommentsDiffTool extends FrameDiffTool {
                          @Nullable final ContentRevision revision,
                          @NotNull final VirtualFile vFile, Editor editor2) {
     final List<Comment> comments = review.getComments();
-    final FilePath filePath = revision == null? null : revision.getFile();
+    final FilePath filePath = new FilePathImpl(vFile);
 
     for (Comment comment : comments) {
       final String id = comment.getReviewItemId();
       final String path = review.getPathById(id);
-      if (filePath != null && path != null && filePath.getPath().endsWith(path) &&
+      if (revision != null && path != null && filePath.getPath().endsWith(path) &&
           revision.getRevisionNumber().asString().equals(comment.getRevision())) {
 
         final MarkupModel markup = editor2.getMarkupModel();
@@ -116,6 +99,34 @@ public class CommentsDiffTool extends FrameDiffTool {
         final ReviewGutterIconRenderer gutterIconRenderer =
           new ReviewGutterIconRenderer(review, vFile, comment);
         highlighter.setGutterIconRenderer(gutterIconRenderer);
+      }
+    }
+  }
+
+  private class CommentableDiffPanel extends DiffPanelImpl {
+    public CommentableDiffPanel(Window window, DiffRequest request) {
+      super(window, request.getProject(), true, true, DiffManagerImpl.FULL_DIFF_DIVIDER_POLYGONS_OFFSET, CommentsDiffTool.this);
+    }
+
+    @Override
+    public void setDiffRequest(DiffRequest request) {
+      super.setDiffRequest(request);
+
+      Object chain = request.getGenericData().get(VcsDataKeys.DIFF_REQUEST_CHAIN.getName());
+      if (chain instanceof ChangeRequestChain) {
+        DiffRequestPresentable currentRequest = ((ChangeRequestChain)chain).getCurrentRequest();
+        if (currentRequest != null) {
+          String path = currentRequest.getPathPresentation();
+          VirtualFile file = LocalFileSystem.getInstance().findFileByPath(path);
+
+          Editor editor2 = getEditor2();
+          addCommentAction(editor2, file, myReview);
+
+          if (myChanges != null && myChanges.length == 1 && myReview != null && file != null) {
+            final ContentRevision revision = myChanges[0].getAfterRevision();
+            addGutter(myReview, revision, file, editor2);
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
When Show Diff is called on a file from a commit, the DiffTool is
shown only once, therefore any data (VirtualFile) requested at this
time, and any modifications to the tool (addComment, addGutter)
will be lost when user moves to the next or previous file
in the diff chain.
1. To customize the diff panel for each Change, we need to extend the
   DiffPanel. Override the new protected method from the FrameDiffTool:
   create a DiffPanelImpl extension that adds comment icons to the
   gutter and adds an action to create a new comment.
2. By moving addCommentAction & addGutter to the DiffPanelImpl
   extension, we can no more override the show() method which has some
   complex logic partly copy-pasted here.
3. Get the VirtualFile not from the DataContext (it would return the
   VF selected by user before calling Show Diff), but from the diff chain.
4. In addCommentAction get the filepath from the virtual file,
   not from the revision (because the revision only for the first file
   in the chain is passed there).
