### PR TITLE
fix compatibility with 146 branch

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -146,15 +146,6 @@
   <project-components>
   </project-components>
 
-  <actions>
-    <action id="CrucibleView.Diff" class="com.intellij.openapi.vcs.changes.actions.ShowDiffAction"
-            icon="AllIcons.Actions.Diff"/>
-
-    <group id="CrucibleViewPopupMenu">
-    <reference ref="CrucibleView.Diff"/>
-    </group>
-  </actions>
-
   <extensions defaultExtensionNs="com.intellij">
     <applicationConfigurable instance="com.jetbrains.crucible.configuration.CrucibleConfigurable"
                              id="com.jetbrains.crucible.configuration.CrucibleConfigurable" displayName="Code Review"/>


### PR DESCRIPTION
the only usage of CrucibleViewPopupMenu was removed in 64c3fc0

com.intellij.openapi.vcs.changes.actions.ShowDiffAction removed in 146.